### PR TITLE
Ajout de la possibilité de forcer l'enregistrement des formulaires

### DIFF
--- a/main/models.py
+++ b/main/models.py
@@ -138,27 +138,6 @@ class Trip(models.Model):
 
         return None
 
-    def clean(self):
-        validation_errors = dict()
-
-        if self.starting_mileage < self.vehicle.mileage:
-            validation_errors["starting_mileage"] = ValidationError(
-                _(
-                    "Le kilométrage de départ ne peut pas être inférieur au kilométrage du véhicule !"
-                )
-            )
-
-        if self.ending_mileage and self.starting_mileage > self.ending_mileage:
-            validation_errors["ending_mileage"] = ValidationError(
-                _(
-                    "Le kilométrage de fin ne peut pas être inférieur au kilométrage de départ !"
-                ),
-                code="invalid",
-            )
-
-        if len(validation_errors) > 0:
-            raise ValidationError(validation_errors)
-
 
 class FuelExpense(models.Model):
     class Meta:

--- a/main/static/css/main.css
+++ b/main/static/css/main.css
@@ -1,17 +1,21 @@
 * {
     --warning-color: #f8e98c;
-    --info-color: #84d3f6
+    --warning-inverse-color: var(--background-color);
+    --info-color: #84d3f6;
 }
 
-.warning, .info {
+.warning,
+.info {
     border-radius: var(--border-radius);
     padding: var(--form-element-spacing-vertical) var(--form-element-spacing-horizontal);
 }
 
 .warning {
     background-color: var(--warning-color);
+    color: var(--warning-inverse-color);
 }
 
 .info {
     background-color: var(--info-color);
+    color: var(--warning-inverse-color);
 }

--- a/main/static/css/pico.css
+++ b/main/static/css/pico.css
@@ -1053,6 +1053,7 @@ a[role=button]:not([href]) {
   pointer-events: none;
 }
 
+
 /**
  * Form elements
  */

--- a/main/templates/main/vehicle_detail.html
+++ b/main/templates/main/vehicle_detail.html
@@ -57,6 +57,12 @@
                         <div>{{ trip_form.ending_time.label_tag }}{{ trip_form.ending_time }}{% for error in trip_form.ending_time.errors %}<small>{{ error }}</small>{% endfor %}</div>
                         <div>{{ trip_form.ending_mileage.label_tag }}{{ trip_form.ending_mileage }}{% for error in trip_form.ending_mileage.errors %}<small>{{ error }}</small>{% endfor %}</div>
                     </div>
+                    {% endif %}
+                    <input type="hidden" name="{{ trip_form.force_validate.name }}" value="{{ trip_form.errors|yesno:'true,false'}}">
+                    {% if trip_form.errors %}
+                    <p class="warning" aria-invalid="true">Le formulaire contient au moins une erreur, vérifiez avant de valider!</p>
+                    {% endif %}
+                    {% if trip_started %}
                     <input type="submit" name="end-trip-form" value="Finir">
                     {% else %}
                     <input type="submit" name="start-trip-form" value="Démarrer">


### PR DESCRIPTION
L'idée est de pouvoir valider un formulaire même après qu'une erreur ait été faite.  
Aujourd'hui, si un utilisateur rentre un kilométrage trop élevé, l'utilisateur suivant ou lui même sera bloqué lors de l'utilisation suivante et ne pourra pas indiquer le kilométrage réel et valider le formulaire.  

## Description fonctionnelle

Lorsqu'un formulaire erroné est envoyé, le formulaire affiche un message indiquant les erreurs ainsi qu'un message invitant à vérifier les informations et à valider à nouveau. La seconde validation de l'utilisitaur n'est pas vérifiée et valide l'enregistrement.

## Description technique

Ajout d'un champ "force_validate" caché dans le formulaire, qui vaut True si le formulaire contient des erreurs (suite à la première validation erronée). Si le formulaire est envoyé avec ce champ, la vérification n'est pas faite côté back et le l'instance est enregistrée même si elle contient des erreurs.
De même si le formulaire contient des erreurs, ajout d'un texte invitant l'utilisateur à vérifier les données


## Next 

Le champ de texte invitant à vérifier pourrait être remplacé par une checkbox validant l'envoi du form malgré les erreurs.  
  
Cette feature n'est implémenté que pour les form start et stop d'un trajet, il pourrait être ajouté à l'essence, qui ne comporte pas encore de validation des données.