### PR TITLE
RESTyfying the API by changing URL for trip management

### DIFF
--- a/main/urls.py
+++ b/main/urls.py
@@ -24,10 +24,10 @@ urlpatterns = [
         name="fuel_expense",
     ),
     path(
-        "vehicles/<uuid:pk>/trip/start", TripStartFormView.as_view(), name="trip_start"
+        "vehicles/<uuid:pk>/trip-start", TripStartFormView.as_view(), name="trip_start"
     ),
-    path("vehicles/<uuid:pk>/trip/end", TripEndFormView.as_view(), name="trip_end"),
+    path("vehicles/<uuid:pk>/trip-end", TripEndFormView.as_view(), name="trip_end"),
     path(
-        "vehicles/<uuid:pk>/trip/abort", TripAbortFormView.as_view(), name="trip_abort"
+        "vehicles/<uuid:pk>/trip-abortion", TripAbortFormView.as_view(), name="trip_abort"
     ),
 ]


### PR DESCRIPTION
Pour respecter au maximum les conventions REST, changements des URLs pour la gestion des trajets. Les verbes ne sont pas autorisés.

Idéalement il faudrait une seule URL `vehicle/{pk}/trip` avec différentes méthodes (POST pour start, PUT pour end et DELETE pour abort) mais les navigateurs ne supportent que POST (ou GET) dans les formulaires...