### PR TITLE
Add DKV map link

### DIFF
--- a/main/static/css/main.css
+++ b/main/static/css/main.css
@@ -22,3 +22,8 @@ input:not([type=submit], [type=button], [type=reset])[readonly] {
     opacity: var(--form-element-disabled-opacity);
     pointer-events: none;
 }
+
+a {
+    margin-top: var(--spacing);
+    margin-bottom: var(--spacing);
+}

--- a/main/templates/main/forms/fuel_expense_form.html
+++ b/main/templates/main/forms/fuel_expense_form.html
@@ -1,6 +1,9 @@
 <form action="{% url 'fuel_expense' vehicle.pk %}" method="post">
     {% csrf_token %}
     <div class="grid">
+        <a href="https://www.dkv-euroservice.com/DKVMaps/">🗺️ Ouvrir la carte des stations de carburant</a>
+    </div>
+    <div class="grid">
         <div>{{ fuel_expense_form.date.as_field_group }}</div>
         <div>{{ fuel_expense_form.mileage.as_field_group }}</div>
     </div>


### PR DESCRIPTION
Ajout d'un lien vers la carte DKV des stations essences dans le formulaire du plein d'essence.

<img width="1227" height="494" alt="image" src="https://github.com/user-attachments/assets/9e4a92db-3ac1-4e2a-9cba-f2d5b001fd9c" />

Voir issue #16 